### PR TITLE
feat(scaffolder): enable forwarding of githubOrgId

### DIFF
--- a/.changeset/flat-ants-ring.md
+++ b/.changeset/flat-ants-ring.md
@@ -1,0 +1,5 @@
+---
+'@humanitec/backstage-plugin-scaffolder-backend-module': minor
+---
+
+Enable forwarding of githubOrgId

--- a/plugins/humanitec-backend-scaffolder-module/src/actions/get-environment.ts
+++ b/plugins/humanitec-backend-scaffolder-module/src/actions/get-environment.ts
@@ -3,9 +3,10 @@ import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 interface EnvironmentAction {
   orgId: string
   cloudProvider?: string
+  githubOrgId?: string
 }
 
-export function createGetEnvironmentAction({ orgId, cloudProvider }: EnvironmentAction) {
+export function createGetEnvironmentAction({ orgId, cloudProvider, githubOrgId }: EnvironmentAction) {
   return createTemplateAction({
     id: 'humanitec:get-environment',
     schema: {
@@ -20,6 +21,9 @@ export function createGetEnvironmentAction({ orgId, cloudProvider }: Environment
           cloudProvider: {
             type: 'string'
           },
+          githubOrgId: {
+            type: 'string'
+          },
           githubOIDCCustomization: {
             type: 'object'
           }
@@ -29,6 +33,7 @@ export function createGetEnvironmentAction({ orgId, cloudProvider }: Environment
     handler: async (ctx) => {
       ctx.output('orgId', orgId);
       ctx.output('cloudProvider', cloudProvider);
+      ctx.output('githubOrgId', githubOrgId);
 
       let githubOIDCCustomization
       if (cloudProvider === 'azure') {

--- a/plugins/humanitec-backend-scaffolder-module/src/module.ts
+++ b/plugins/humanitec-backend-scaffolder-module/src/module.ts
@@ -43,6 +43,7 @@ export const humanitecModule = createBackendModule({
           createGetEnvironmentAction({
             orgId: config.getString('humanitec.orgId'),
             cloudProvider: config.getOptionalString('humanitec.cloudProvider'),
+            githubOrgId: config.getOptionalString('humanitec.githubOrgId'),
           }),
         );
       },


### PR DESCRIPTION
Enable forwarding of the `humanitec.githubOrgId` to be able to inject it into the template.