### PR TITLE
Update build scripts in GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,10 @@ jobs:
         with:
           node-version: 20
 
-      - run: corepack yarn install --immutable
-
-      - run: corepack yarn tsc
-
-      - run: corepack yarn build:all
+      - run: corepack enable
+      - run: yarn install --immutable
+      - run: yarn tsc
+      - run: yarn build:all
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/scripts/build-dynamic-plugins.sh
+++ b/scripts/build-dynamic-plugins.sh
@@ -16,20 +16,20 @@ echo ===================================
 echo Exporting frontend plugin
 echo ===================================
 cd "$pluginDir/humanitec"
-npx --yes @janus-idp/cli@1.13.1 package export-dynamic-plugin --clean
+npx --yes @janus-idp/cli@3.6.1 package export-dynamic-plugin --clean
 echo "# @humanitec/backstage-plugin-dynamic$dynamicReadmeHeader$(cat ./dist-dynamic/README.md)" > ./dist-dynamic/README.md
 npm pack ./dist-dynamic --pack-destination "$outputDir"
 echo ===================================
 echo Exporting backend plugin
 echo ===================================
 cd "$pluginDir/humanitec-backend"
-npx --yes @janus-idp/cli@3.6.0 package export-dynamic-plugin --clean
+npx --yes @janus-idp/cli@3.6.1 package export-dynamic-plugin --clean
 echo "# @humanitec/backstage-plugin-backend-dynamic$dynamicReadmeHeader$(cat ./dist-dynamic/README.md)" > ./dist-dynamic/README.md
 npm pack ./dist-dynamic --pack-destination "$outputDir"
 echo ===================================
 echo Exporting backend scaffolder module
 echo ===================================
 cd "$pluginDir/humanitec-backend-scaffolder-module"
-npx --yes @janus-idp/cli@3.6.0 package export-dynamic-plugin --clean
+npx --yes @janus-idp/cli@3.6.1 package export-dynamic-plugin --clean
 echo "# @humanitec/backstage-plugin-scaffolder-backend-module-dynamic$dynamicReadmeHeader $(cat ./dist-dynamic/README.md)" > ./dist-dynamic/README.md
 npm pack ./dist-dynamic --pack-destination "$outputDir"


### PR DESCRIPTION
A few missing bits since the Yarn upgrade:
https://github.com/humanitec/humanitec-backstage-plugins/actions/workflows/publish.yml

Notably, this fixes the `yarn release:…` calls in .github/workflows/publish.yml