### PR TITLE
chore: add notice before archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # humanitec-backstage-plugins
 
+> [!WARNING]
+> The Humanitec Backstage plugin continues to work with Humanitec v1, but is no longer
+> maintained. Of note, it is not compatible with v2.
+>
+> A Backstage plugin for Humanitec Platform Orchestrator (v2) is on our roadmap.
+
 This repository contains [Backstage](https://backstage.io/) plugins to interact with the [Humanitec Platform Orchestrator](https://developer.humanitec.com/platform-orchestrator/overview/) from your Backstage Portal.
 
 * [humanitec](./plugins/humanitec) Show workloads, environments and resources deployed by Humanitec Platform Orchestrator.

--- a/plugins/humanitec-backend-scaffolder-module/README.md
+++ b/plugins/humanitec-backend-scaffolder-module/README.md
@@ -1,5 +1,11 @@
 # @humanitec/backstage-plugin-scaffolder-backend-module
 
+> [!WARNING]
+> The Humanitec Backstage plugin continues to work with Humanitec v1, but is no longer
+> maintained. Of note, it is not compatible with v2.
+>
+> A Backstage plugin for Humanitec Platform Orchestrator (v2) is on our roadmap.
+
 `@humanitec/backstage-plugin-scaffolder-backend-module` is a new backend system module to add the humanitec action in the scaffolder
 
 ## Scaffolder Actions

--- a/plugins/humanitec-backend/README.md
+++ b/plugins/humanitec-backend/README.md
@@ -1,5 +1,11 @@
 # @humanitec/backstage-plugin-backend
 
+> [!WARNING]
+> The Humanitec Backstage plugin continues to work with Humanitec v1, but is no longer
+> maintained. Of note, it is not compatible with v2.
+>
+> A Backstage plugin for Humanitec Platform Orchestrator (v2) is on our roadmap.
+
 `@humanitec/backstage-plugin-backend` is a plugin for the Backstage backend app. It provides a route that `@humanitec/backstage-plugin` will use to connect to Humanitec API.
 
 ## Installation

--- a/plugins/humanitec/README.md
+++ b/plugins/humanitec/README.md
@@ -1,5 +1,11 @@
 # @humanitec/backstage-plugin
 
+> [!WARNING]
+> The Humanitec Backstage plugin continues to work with Humanitec v1, but is no longer
+> maintained. Of note, it is not compatible with v2.
+>
+> A Backstage plugin for Humanitec Platform Orchestrator (v2) is on our roadmap.
+
 `@humanitec/backstage-plugin` is a plugin for the Backstage frontend app. It shows information about environments, workloads and resources on an entity page.
 
 ![screenshot](./screenshot.png)


### PR DESCRIPTION
Updating the projects READMEs before archiving this project.

(Actions are broken due to an unrelated change to an upstream repo, and are unrelated to this PR's content.)